### PR TITLE
feat: render monthly HTML report

### DIFF
--- a/ipc-ushuaia/src/reporting/__init__.py
+++ b/ipc-ushuaia/src/reporting/__init__.py
@@ -1,0 +1,5 @@
+"""Utilidades para generar reportes HTML."""
+
+from .render import render_monthly_report
+
+__all__ = ["render_monthly_report"]

--- a/ipc-ushuaia/src/reporting/render.py
+++ b/ipc-ushuaia/src/reporting/render.py
@@ -1,0 +1,76 @@
+"""Renderizado de reportes mensuales en HTML mediante Jinja2."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+
+import pandas as pd
+from jinja2 import Environment, FileSystemLoader
+
+# Directorio base del proyecto
+BASE_DIR = Path(__file__).resolve().parents[2]
+TEMPLATE_DIR = BASE_DIR / "templates"
+REPORT_DIR = BASE_DIR / "reports"
+
+
+def render_monthly_report(
+    period: str,
+    df_series: pd.DataFrame,
+    df_breakdown: pd.DataFrame,
+    img_paths: Dict[str, str],
+    meta: Dict[str, Any],
+) -> Path:
+    """Genera un reporte mensual en HTML.
+
+    Parameters
+    ----------
+    period:
+        Período del reporte (``YYYY-MM``).
+    df_series:
+        Serie histórica con las columnas ``cba_ae``, ``cba_family``, ``idx``,
+        ``mom`` e ``yoy``.
+    df_breakdown:
+        Desglose de variaciones por ítem.
+    img_paths:
+        Rutas a los gráficos a incrustar en el reporte.
+    meta:
+        Metadatos adicionales para el reporte.
+
+    Returns
+    -------
+    Path
+        Ruta al archivo HTML generado.
+    """
+
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR), autoescape=True)
+    template = env.get_template("monthly_report.html")
+
+    latest = df_series.iloc[-1]
+    kpis = {
+        "CBA AE": f"{latest['cba_ae']:.2f}",
+        "CBA familia": f"{latest.get('cba_family', latest['cba_ae'] * 3.09):.2f}",
+        "m/m": f"{latest.get('mom', 0.0):.2f}%",
+        "i.a.": f"{latest.get('yoy', 0.0):.2f}%",
+        "índice": f"{latest.get('idx', 0.0):.2f}",
+    }
+
+    breakdown = df_breakdown.to_dict(orient="records")
+
+    html = template.render(
+        period=period,
+        kpis=kpis,
+        img_paths=img_paths,
+        breakdown=breakdown,
+        meta=meta,
+    )
+
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = REPORT_DIR / f"monthly_{period}.html"
+    with open(output_path, "w", encoding="utf-8") as fh:
+        fh.write(html)
+
+    # TODO: Integrar estilos y plantillas responsivas.
+    # TODO: Revisar atributos de accesibilidad (ej. etiquetas ARIA).
+
+    return output_path

--- a/ipc-ushuaia/templates/monthly_report.html
+++ b/ipc-ushuaia/templates/monthly_report.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <title>Reporte Mensual {{ period }}</title>
+    <!-- TODO: aplicar estilos CSS coherentes con la identidad visual -->
+    <!-- TODO: revisar atributos de accesibilidad (ej. roles, ARIA) -->
+</head>
+<body>
+    <section id="kpis">
+        <h1>Indicadores Clave</h1>
+        <ul>
+        {% for key, value in kpis.items() %}
+            <li><strong>{{ key }}:</strong> {{ value }}</li>
+        {% endfor %}
+        </ul>
+    </section>
+
+    <section id="index-chart">
+        <h2>Evolución del índice</h2>
+        <img src="{{ img_paths.index }}" alt="Gráfico del índice" />
+        <!-- TODO: proveer descripciones más completas para lectores de pantalla -->
+    </section>
+
+    <section id="breakdown">
+        <h2>Top subas y bajas</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>\u00cdtem</th>
+                    <th>Variación</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for row in breakdown %}
+                <tr>
+                    <td>{{ row.item }}</td>
+                    <td>{{ row.delta }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </section>
+</body>
+</html>

--- a/ipc-ushuaia/tests/test_rendering.py
+++ b/ipc-ushuaia/tests/test_rendering.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from pathlib import Path
+
+from src.reporting.render import render_monthly_report
+
+
+def test_render_monthly_report(tmp_path):
+    period = "2024-01"
+    series = pd.DataFrame({
+        "period": ["2023-12", "2024-01"],
+        "cba_ae": [100.0, 110.0],
+    })
+    series["cba_family"] = series["cba_ae"] * 3.09
+    series["idx"] = (series["cba_ae"] / series["cba_ae"].iloc[0]) * 100
+    series["mom"] = series["idx"].pct_change() * 100
+    series["yoy"] = series["idx"].pct_change(12) * 100
+
+    breakdown = pd.DataFrame({"item": ["A", "B"], "delta": [1.5, -0.5]})
+    img_paths = {"index": "index.png"}
+
+    output = render_monthly_report(period, series, breakdown, img_paths, meta={})
+    assert output.exists()
+    html = output.read_text(encoding="utf-8")
+    assert "Indicadores Clave" in html
+    assert "Top subas y bajas" in html


### PR DESCRIPTION
## Summary
- add Jinja2 template for monthly report with KPI, index chart and top movers table
- implement `render_monthly_report` to fill template and save HTML output
- cover rendering with a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c072fd794883298e6239dab8827a8b