### PR TITLE
feat(reporting): add metadata footer

### DIFF
--- a/ipc-ushuaia/src/reporting/__init__.py
+++ b/ipc-ushuaia/src/reporting/__init__.py
@@ -1,10 +1,20 @@
 """Utilidades para generar reportes HTML."""
 
 from .render import render_monthly_report
-from .plots import plot_index_series, plot_category_bars
+from .meta import build_meta
 
 __all__ = [
     "render_monthly_report",
     "plot_index_series",
     "plot_category_bars",
+    "build_meta",
 ]
+
+try:
+    from .plots import plot_index_series, plot_category_bars
+except ModuleNotFoundError:  # pragma: no cover - dependencias opcionales
+    def plot_index_series(*args, **kwargs):  # type: ignore[override]
+        raise RuntimeError("matplotlib es requerido para generar gr\u00e1ficos")
+
+    def plot_category_bars(*args, **kwargs):  # type: ignore[override]
+        raise RuntimeError("matplotlib es requerido para generar gr\u00e1ficos")

--- a/ipc-ushuaia/src/reporting/meta.py
+++ b/ipc-ushuaia/src/reporting/meta.py
@@ -1,0 +1,39 @@
+"""Metadatos comunes para los reportes.
+
+Centraliza valores reutilizables como la metodolog\u00eda, la fuente de precios y la versi\u00f3n del scraper.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+SCRAPER_VERSION = "0.1.0"
+
+SUMMARY_METHODOLOGY = (
+    "Canasta b\u00e1sica alimentaria fija; precios finales al consumidor; índice base 100 en el primer per\u00edodo."
+)
+SOURCE = "La An\u00f3nima Ushuaia"
+
+def build_meta(run_id: str, extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Construye un diccionario de metadatos comunes para los reportes.
+
+    Parameters
+    ----------
+    run_id:
+        Identificador de ejecuci\u00f3n del scraper.
+    extra:
+        Metadatos adicionales que pueden sobreescribir los predeterminados.
+
+    Returns
+    -------
+    dict
+        Diccionario con metadatos enriquecidos.
+    """
+    meta = {
+        "methodology": SUMMARY_METHODOLOGY,
+        "source": SOURCE,
+        "scraper_version": SCRAPER_VERSION,
+        "run_id": run_id,
+    }
+    if extra:
+        meta.update(extra)
+    return meta

--- a/ipc-ushuaia/src/reporting/render.py
+++ b/ipc-ushuaia/src/reporting/render.py
@@ -8,6 +8,8 @@ from typing import Dict, Any
 import pandas as pd
 from jinja2 import Environment, FileSystemLoader
 
+from .meta import build_meta
+
 # Directorio base del proyecto
 BASE_DIR = Path(__file__).resolve().parents[2]
 TEMPLATE_DIR = BASE_DIR / "templates"
@@ -35,7 +37,8 @@ def render_monthly_report(
     img_paths:
         Rutas a los gráficos a incrustar en el reporte.
     meta:
-        Metadatos adicionales para el reporte.
+        Metadatos adicionales para el reporte. Si faltan las claves comunes,
+        se completan con :func:`src.reporting.meta.build_meta`.
 
     Returns
     -------
@@ -57,12 +60,14 @@ def render_monthly_report(
 
     breakdown = df_breakdown.to_dict(orient="records")
 
+    enriched_meta = build_meta(meta.get("run_id", ""), extra=meta)
+
     html = template.render(
         period=period,
         kpis=kpis,
         img_paths=img_paths,
         breakdown=breakdown,
-        meta=meta,
+        meta=enriched_meta,
     )
 
     REPORT_DIR.mkdir(parents=True, exist_ok=True)

--- a/ipc-ushuaia/templates/monthly_report.html
+++ b/ipc-ushuaia/templates/monthly_report.html
@@ -41,5 +41,11 @@
             </tbody>
         </table>
     </section>
+
+    <footer>
+        <p>{{ meta.methodology }}</p>
+        <p>Fuente: {{ meta.source }}</p>
+        <p>Scraper v{{ meta.scraper_version }} | run_id: {{ meta.run_id }}</p>
+    </footer>
 </body>
 </html>

--- a/ipc-ushuaia/tests/test_rendering.py
+++ b/ipc-ushuaia/tests/test_rendering.py
@@ -2,6 +2,7 @@ import pandas as pd
 from pathlib import Path
 
 from src.reporting.render import render_monthly_report
+from src.reporting.meta import build_meta, SCRAPER_VERSION, SOURCE
 
 
 def test_render_monthly_report(tmp_path):
@@ -18,8 +19,12 @@ def test_render_monthly_report(tmp_path):
     breakdown = pd.DataFrame({"item": ["A", "B"], "delta": [1.5, -0.5]})
     img_paths = {"index": "index.png"}
 
-    output = render_monthly_report(period, series, breakdown, img_paths, meta={})
+    meta = build_meta(run_id="test-run")
+    output = render_monthly_report(period, series, breakdown, img_paths, meta)
     assert output.exists()
     html = output.read_text(encoding="utf-8")
     assert "Indicadores Clave" in html
     assert "Top subas y bajas" in html
+    assert SOURCE in html
+    assert f"Scraper v{SCRAPER_VERSION}" in html
+    assert "run_id: test-run" in html


### PR DESCRIPTION
## Summary
- centralize common report metadata including methodology, source and scraper version
- enrich monthly report rendering with metadata and add footer in the HTML output
- cover metadata footer in rendering tests

## Testing
- `cd ipc-ushuaia && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c074d444408329b8d3fd0d6c62717b