### PR TITLE
docs: add scheduler examples

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -18,3 +18,19 @@
 - Reintentar extracción por lotes.
 - Usar HTML capturado para depurar selectores.
 - Documentar cualquier ajuste metodológico.
+
+## Ejecución en Windows
+Ejemplo con Task Scheduler utilizando `schtasks`:
+
+```bat
+cd C:\\ruta\\al\\proyecto
+schtasks /Create /SC DAILY /TN "IPC-Ushuaia" /TR "cmd /c cd %CD% && python ipc-ushuaia\\src\\cli.py --run --export csv >> ipc-ushuaia\\logs\\scheduler.log 2>&1" /ST 02:00
+```
+
+## Ejecución en Linux
+Ejemplo de cron (`crontab -e`) con redirección de logs:
+
+```bash
+0 2 * * * cd /ruta/al/proyecto && /usr/bin/python3 ipc-ushuaia/src/cli.py --run --export csv >> ipc-ushuaia/logs/cron.log 2>&1
+```
+


### PR DESCRIPTION
## Summary
- document Windows Task Scheduler usage via `schtasks`
- show Linux cron job example with log redirection

## Testing
- `pip install --disable-pip-version-check --no-cache-dir -r ipc-ushuaia/requirements.txt`
- `pytest ipc-ushuaia/tests`

------
https://chatgpt.com/codex/tasks/task_e_68c1a0d7d2fc8329b8099bc8eedfd661