### PR TITLE
Add integration test for anonymized HTML to CSV pipeline

### DIFF
--- a/tests/expected/cba_prices.csv
+++ b/tests/expected/cba_prices.csv
@@ -1,0 +1,3 @@
+item,sku,price,pack_size,source,adjusted_qty
+Pan fresco,123,100.0,1,preferred,1.0
+Leche entera,456,200.0,1,preferred,2.0

--- a/tests/expected/products.csv
+++ b/tests/expected/products.csv
@@ -1,0 +1,3 @@
+name,sku,price,promo_price,pack_size
+Pan fresco La Anónima,123,120.0,100.0,1.0
+Leche entera,456,200.0,,1.0

--- a/tests/fixtures/sample_products.html
+++ b/tests/fixtures/sample_products.html
@@ -1,0 +1,15 @@
+<html>
+  <body>
+    <div class="product" data-sku="123">
+      <span class="product-name">Pan fresco La Anónima</span>
+      <span class="product-price">$120</span>
+      <span class="product-promo">$100</span>
+      <span class="product-pack">1 kg</span>
+    </div>
+    <div class="product" data-sku="456">
+      <span class="product-name">Leche entera</span>
+      <span class="product-price">$200</span>
+      <span class="product-pack">1 L</span>
+    </div>
+  </body>
+</html>

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -1,0 +1,76 @@
+import csv
+from pathlib import Path
+from typing import List, Dict, Any
+
+from bs4 import BeautifulSoup
+
+from src import parser, normalizer
+
+FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
+EXPECTED_DIR = Path(__file__).resolve().parents[1] / "expected"
+
+
+def _parse_html_products(html_path: Path) -> List[Dict[str, Any]]:
+    with open(html_path, encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
+    products = []
+    for div in soup.select("div.product"):
+        name = div.select_one(".product-name").get_text(strip=True)
+        sku = div["data-sku"]
+        price = float(div.select_one(".product-price").get_text(strip=True).replace("$", ""))
+        promo_tag = div.select_one(".product-promo")
+        promo_price = (
+            float(promo_tag.get_text(strip=True).replace("$", ""))
+            if promo_tag else None
+        )
+        pack_text = div.select_one(".product-pack").get_text(strip=True)
+        pack_size = float(pack_text.split()[0].replace(",", "."))
+        products.append({
+            "name": name,
+            "sku": sku,
+            "price": price,
+            "promo_price": promo_price,
+            "pack_size": pack_size,
+        })
+    return products
+
+
+def _write_csv(path: Path, rows: List[Dict[str, Any]], fieldnames: List[str]) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _read_csv(path: Path) -> List[Dict[str, str]]:
+    with open(path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def test_full_pipeline(tmp_path: Path) -> None:
+    html_path = FIXTURES_DIR / "sample_products.html"
+    products = _parse_html_products(html_path)
+
+    products_csv = tmp_path / "products.csv"
+    _write_csv(products_csv, products, ["name", "sku", "price", "promo_price", "pack_size"])
+    assert _read_csv(products_csv) == _read_csv(EXPECTED_DIR / "products.csv")
+
+    cba_catalog = normalizer.load_cba_catalog(str(FIXTURES_DIR / "cba_catalog.csv"))
+    mapping = parser.map_products_to_cba(products, cba_catalog)
+    adjusted = normalizer.adjust_quantities(cba_catalog, ae_multiplier=1.0)
+
+    rows = []
+    for row in adjusted:
+        info = mapping[row["item"]]
+        rows.append({
+            "item": row["item"],
+            "sku": info["sku"],
+            "price": f"{info['price']:.1f}" if info["price"] is not None else "",
+            "pack_size": str(int(info["pack_size"])) if info["pack_size"] is not None else "",
+            "source": info["source"],
+            "adjusted_qty": f"{row['adjusted_qty']:.1f}" if row["adjusted_qty"] is not None else "",
+        })
+
+    output_csv = tmp_path / "cba_prices.csv"
+    _write_csv(output_csv, rows, ["item", "sku", "price", "pack_size", "source", "adjusted_qty"])
+    assert _read_csv(output_csv) == _read_csv(EXPECTED_DIR / "cba_prices.csv")


### PR DESCRIPTION
## Summary
- add anonymized HTML fixture and expected CSV outputs
- test full pipeline from parsing HTML to CSV export

## Testing
- `PYTHONPATH=. pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a970922c8329a6b71d251a053b38