### PR TITLE
Add CI workflow with coverage gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ipc-ushuaia/requirements.txt pytest-cov
+      - name: Run tests with coverage
+        run: |
+          PYTHONPATH=$GITHUB_WORKSPACE pytest tests --cov=src --cov-report=xml --cov-report=term --cov-fail-under=80


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies and run pytest coverage
- fail build if tests fail or coverage drops below 80%

## Testing
- `PYTHONPATH=$PWD pytest tests --cov=src --cov-report=xml --cov-report=term --cov-fail-under=80` *(fails: coverage 54% < 80%)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab92cdc08329a6de9afb0aece0c6