### PR TITLE
feat: expose normalization modules in app package

### DIFF
--- a/ipc-ushuaia/src/index_engine.py
+++ b/ipc-ushuaia/src/index_engine.py
@@ -1,0 +1,53 @@
+"""
+Motor de cálculo de CBA, AE, familia tipo, índice base=100 y variaciones.
+Incluye lógica de cálculo, actualización de serie histórica y validaciones automáticas.
+"""
+
+import pandas as pd
+from typing import List, Dict, Any
+
+def calculate_cba(adjusted_catalog: List[Dict[str, Any]], sku_prices: Dict[str, float]) -> float:
+	"""
+	Calcula el costo total de la CBA ajustada por AE/familia, usando los precios de los SKUs mapeados.
+	Si falta precio para algún ítem, lo ignora y lo reporta por separado.
+	"""
+	total = 0.0
+	missing = []
+	for row in adjusted_catalog:
+		item = row['item']
+		qty = row.get('adjusted_qty')
+		price = sku_prices.get(item)
+		if qty is not None and price is not None:
+			total += float(qty) * float(price)
+		else:
+			missing.append(item)
+	return total, missing
+
+def calculate_index(series: pd.Series, base_period: str) -> pd.Series:
+	"""
+	Calcula el índice base=100 para la serie histórica de CBA.
+	"""
+	base_value = series.loc[base_period]
+	return (series / base_value) * 100
+
+def calculate_variations(index_series: pd.Series) -> pd.DataFrame:
+	"""
+	Calcula variaciones mensuales (m/m) e interanuales (i.a.) del índice.
+	"""
+	df = pd.DataFrame({'index': index_series})
+	df['var_mm'] = df['index'].pct_change() * 100
+	df['var_ia'] = df['index'].pct_change(12) * 100
+	return df
+
+def validate_series(df: pd.DataFrame) -> Dict[str, Any]:
+	"""
+	Valida integridad de la serie histórica: valores nulos, outliers, gaps temporales.
+	"""
+	summary = {
+		'missing': df.isnull().sum().to_dict(),
+		'outliers': df[(df['index'] > df['index'].mean() + 3*df['index'].std())].index.tolist(),
+		'gaps': df.index.to_series().diff().dt.days.gt(40).sum() if hasattr(df.index, 'to_series') else None
+	}
+	return summary
+
+# TODO: Integrar con exporter.py para salida CSV/HTML/JSON y con normalizer.py para validaciones

--- a/ipc-ushuaia/src/normalize/__init__.py
+++ b/ipc-ushuaia/src/normalize/__init__.py
@@ -1,0 +1,3 @@
+from .units import parse_size, to_base_units
+from .pricing import unit_price
+__all__ = ["parse_size", "to_base_units", "unit_price"]

--- a/ipc-ushuaia/src/normalize/pricing.py
+++ b/ipc-ushuaia/src/normalize/pricing.py
@@ -1,0 +1,19 @@
+"""
+Normalizador de precios por unidad base.
+Calcula precio por unidad base a partir de precio, tamaño y unidad.
+"""
+
+def unit_price(price: float, pack_size: float, pack_unit: str, base_unit: str) -> float:
+    """
+    Calcula el precio por unidad base.
+    Ej: price=300, pack_size=900, pack_unit='ml', base_unit='ml' -> 0.333...
+    """
+    from .units import to_base_units
+
+    # Convertir pack_size a la unidad base deseada
+    base_qty, base_unit_conv = to_base_units(pack_size, pack_unit)
+    if base_unit_conv != base_unit:
+        raise ValueError(f"No se puede convertir {pack_unit} a {base_unit}")
+    if base_qty == 0:
+        raise ValueError("El tamaño del pack no puede ser cero")
+    return price / base_qty

--- a/ipc-ushuaia/src/normalize/units.py
+++ b/ipc-ushuaia/src/normalize/units.py
@@ -1,0 +1,100 @@
+"""
+Parser y normalizador de tamaños y unidades.
+Detecta patrones como '1 kg', '900 ml', 'x2 500g', 'docena', fracciones y multi-pack.
+"""
+
+import re
+from typing import Tuple
+
+# Alias y conversiones
+_unit_aliases = {
+    'g': 'g', 'gr': 'g', 'grs': 'g',
+    'kg': 'kg', 'kilo': 'kg',
+    'ml': 'ml', 'cc': 'ml',
+    'l': 'l', 'lt': 'l', 'litro': 'l',
+    'unidad': 'unidad', 'un': 'unidad', 'u': 'unidad',
+    'unidades': 'unidad',  # Soporte plural
+    'docena': 'docena', 'docenas': 'docena',
+}
+
+_unit_multipliers = {
+    'g': 1,
+    'kg': 1000,
+    'ml': 1,
+    'l': 1000,
+    'unidad': 1,
+    'docena': 12,
+}
+
+def _parse_fraction(s):
+    s = s.replace('½', '1/2').replace('¼', '1/4')
+    if '/' in s:
+        num, den = s.split('/')
+        return float(num) / float(den)
+    return float(s)
+
+def parse_size(text: str) -> Tuple[float, str]:
+    """
+    Extrae cantidad y unidad base de una descripción textual.
+    Ej: 'x2 500g' -> (1000, 'g')
+    """
+    text = text.lower().strip()
+    # Multi-pack: xN ...
+    m = re.match(r"x\s*(\d+)\s*(.*)", text)
+    if m:
+        mult = int(m.group(1))
+        rest = m.group(2).strip()
+        qty, unit = parse_size(rest)
+        return mult * qty, unit
+    # Multi-pack con fracción: xN fracción unidad
+    m = re.match(r"x\s*(\d+)\s*([\d/.,]+)\s*([a-zA-Z]+)", text)
+    if m:
+        mult = int(m.group(1))
+        qty = _parse_fraction(m.group(2).replace(',', '.'))
+        unit = m.group(3)
+        base_qty, base_unit = to_base_units(qty, unit)
+        return mult * base_qty, base_unit
+    # Fracción: 1/2 kg, 0.5 kg, ½ kg
+    m = re.match(r"([\d/.,]+)\s*([a-zA-Z]+)", text)
+    if m:
+        qty = _parse_fraction(m.group(1).replace(',', '.'))
+        unit = m.group(2)
+        return to_base_units(qty, unit)
+    # Docena
+    if 'docena' in text:
+        m = re.match(r"(\d+)\s*docena", text)
+        if m:
+            return int(m.group(1)) * 12, 'unidad'
+        return 12, 'unidad'
+    # Unidades
+    m = re.match(r"(\d+)\s*unidades?", text)
+    if m:
+        return int(m.group(1)), 'unidad'
+    # Solo número (asumir unidad)
+    m = re.match(r"(\d+)$", text)
+    if m:
+        return float(m.group(1)), 'unidad'
+    # Si solo dice 'docena'
+    if text.strip() == 'docena':
+        return 12, 'unidad'
+    raise ValueError(f"No se pudo parsear tamaño: {text}")
+
+def to_base_units(value: float, unit: str) -> Tuple[float, str]:
+    """
+    Convierte a unidad base (g, ml, unidad).
+    Ej: (1.5, 'kg') -> (1500, 'g')
+    """
+    unit = unit.lower()
+    if unit not in _unit_aliases:
+        raise ValueError(f"Unidad desconocida: {unit}")
+    canonical = _unit_aliases[unit]
+    if canonical not in _unit_multipliers:
+        raise ValueError(f"Unidad no convertible: {unit}")
+    mult = _unit_multipliers[canonical]
+    if canonical == 'docena':
+        return value * mult, 'unidad'
+    if canonical == 'kg':
+        return value * mult, 'g'
+    if canonical == 'l':
+        return value * mult, 'ml'
+    return value * mult, canonical

--- a/ipc-ushuaia/src/normalizer.py
+++ b/ipc-ushuaia/src/normalizer.py
@@ -1,0 +1,62 @@
+"""
+Normalizador de unidades, precios y cantidades ajustables por AE/familia.
+Incluye validaciones de integridad y consistencia de la canasta.
+"""
+
+import csv
+from typing import List, Dict, Any
+
+def load_cba_catalog(path: str) -> List[Dict[str, Any]]:
+    """
+    Carga la canasta básica alimentaria desde un CSV.
+    """
+    with open(path, newline='', encoding='utf-8') as csvfile:
+        # Permite comentarios al inicio de línea con '#', útiles para documentar supuestos en fixtures.
+        filtered = (line for line in csvfile if not line.lstrip().startswith('#'))
+        reader = csv.DictReader(filtered)
+        return [row for row in reader]
+
+def adjust_quantities(cba_catalog: List[Dict[str, Any]], ae_multiplier: float = 1.0) -> List[Dict[str, Any]]:
+    """
+    Ajusta las cantidades de cada alimento según el multiplicador de AE/familia.
+    """
+    adjusted = []
+    for row in cba_catalog:
+        row_copy = row.copy()
+        try:
+            base_qty = float(row['monthly_qty_value'])
+            row_copy['adjusted_qty'] = base_qty * ae_multiplier
+        except (ValueError, KeyError):
+            row_copy['adjusted_qty'] = None
+        adjusted.append(row_copy)
+    return adjusted
+
+def validate_cba(cba_catalog: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Valida integridad y consistencia de la canasta:
+    - Suma por rubro
+    - Consistencia de unidades
+    - Flags si falta SKU o hay unidades inconsistentes
+    """
+    summary = {}
+    unit_set = set()
+    missing_qty = []
+    for row in cba_catalog:
+        unit_set.add(row.get('monthly_qty_unit', ''))
+        if not row.get('monthly_qty_value'):
+            missing_qty.append(row.get('item', ''))
+    summary['units'] = list(unit_set)
+    summary['missing_qty'] = missing_qty
+    # Suma por rubro
+    by_category = {}
+    for row in cba_catalog:
+        cat = row.get('category', 'Otros')
+        try:
+            qty = float(row['monthly_qty_value'])
+        except (ValueError, KeyError):
+            qty = 0
+        by_category[cat] = by_category.get(cat, 0) + qty
+    summary['sum_by_category'] = by_category
+    return summary
+
+# TODO: Integrar con el parser y el motor de cálculo para matching y prorrateos

--- a/ipc-ushuaia/src/parser.py
+++ b/ipc-ushuaia/src/parser.py
@@ -1,0 +1,71 @@
+"""Parser de productos y mapeo a la CBA."""
+from typing import Any, Dict, List, Optional
+
+# TODO: Implementar extracción real desde HTML/JSON de La Anónima
+
+
+def _final_unit_price(product: Dict[str, Any]) -> Optional[float]:
+    """Devuelve el precio por unidad considerando promociones."""
+    if product.get("unit_price") is not None:
+        return product.get("unit_price")
+
+    price = product.get("promo_price")
+    if price is None:
+        price = product.get("price")
+
+    pack_size = product.get("pack_size")
+    try:
+        return price / float(pack_size) if price is not None and pack_size else None
+    except (TypeError, ValueError):
+        return None
+
+
+def match_sku_to_cba(product: Dict[str, Any], cba_row: Dict[str, Any]) -> bool:
+    """Heurística de matching por nombre, marca, tamaño y palabras clave."""
+    name = product.get("name", "").lower()
+    preferred = [k.strip() for k in cba_row.get("preferred_keywords", "").split(";")]
+    fallback = [k.strip() for k in cba_row.get("fallback_keywords", "").split(";")]
+    for kw in preferred:
+        if kw and kw in name:
+            return True
+    for kw in fallback:
+        if kw and kw in name:
+            return True
+    return False
+
+
+def map_products_to_cba(products: List[Dict[str, Any]], cba_catalog: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Mapea productos scrapeados a los ítems de la CBA."""
+    mapping: Dict[str, Dict[str, Any]] = {}
+    for cba_row in cba_catalog:
+        matches: List[Dict[str, Any]] = []
+        for prod in products:
+            if match_sku_to_cba(prod, cba_row):
+                prod_copy = prod.copy()
+                prod_copy["unit_price"] = _final_unit_price(prod_copy)
+                matches.append(prod_copy)
+        if matches:
+            best = min(matches, key=lambda x: x.get("unit_price", float("inf")))
+            mapping[cba_row["item"]] = {
+                "sku": best.get("sku"),
+                "price": best.get("unit_price"),
+                "pack_size": best.get("pack_size"),
+                "source": (
+                    "preferred"
+                    if any(
+                        kw in best.get("name", "").lower()
+                        for kw in cba_row.get("preferred_keywords", "").split(";")
+                    )
+                    else "fallback"
+                ),
+            }
+        else:
+            mapping[cba_row["item"]] = {
+                "sku": None,
+                "price": None,
+                "pack_size": None,
+                "source": "missing",
+            }
+    return mapping
+
+# TODO: Documentar y testear reglas de sustitución y prorrateo


### PR DESCRIPTION
## Summary
- copy core normalizer, parser, index_engine and unit helpers into app's `src`
- ensure pricing utilities support consistent unit conversions

## Testing
- `pytest ipc-ushuaia/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1d85f0a1c8329b6ea369b79f7ae3c