### PR TITLE
feat: load configuration from env and verify dependencies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 # Example environment variables
+BRANCH=main
+HEADLESS=true
+MAX_RETRIES=3
+DELAYS=1.5
+USER_AGENT=Mozilla/5.0
+OUTPUT_DIRS=data/raw,data/processed
 API_KEY=your_api_key_here
 EMAIL=user@example.com

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ Este repositorio reúne **documentos guía** para orientar a Copilot/Codex y a l
 
 1. Posicionarse en la carpeta `ipc-ushuaia/`.
 2. Instalar dependencias con `pip install -r requirements.txt`.
+3. Instalar Playwright y el navegador Chromium:
+
+```bash
+pip install playwright
+playwright install chromium
+```
 
 ## Configuración
 
-- Copiar `.env.example` a `.env` y completar valores como `API_KEY` y `EMAIL`.
-- Ajustar `config.toml` según el entorno; el archivo define opciones como `branch`, `headless`, `delays`, `retries` y `base_period`.
+- Copiar `.env.example` a `.env` y completar valores como `BRANCH`, `HEADLESS`, `MAX_RETRIES`, `DELAYS`, `USER_AGENT`, `OUTPUT_DIRS`, `API_KEY` y `EMAIL`.
+- Ajustar `config.toml` según el entorno; el archivo define opciones como `branch`, `headless`, `delays`, `max_retries`, `user_agent` y `output_dirs`.
 
 ## Ejecución
 
@@ -34,6 +40,8 @@ Ejecutar la aplicación con:
 ```bash
 python -m src.cli run
 ```
+
+El subcomando `run` dispara el flujo completo utilizando la configuración cargada.
 
 ## Jerarquía de carpetas
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 branch = "main"
 headless = true
 delays = 1.5
-retries = 3
-base_period = "2024-01"
+max_retries = 3
+user_agent = "Mozilla/5.0"
+output_dirs = ["data/raw", "data/processed"]

--- a/src/config.py
+++ b/src/config.py
@@ -10,17 +10,25 @@ from dataclasses import dataclass
 from pathlib import Path
 import os
 import tomllib
+from typing import Iterable
+
+
+def _str_to_bool(value: str) -> bool:
+    """Return ``True`` if the string represents a truthy value."""
+
+    return value.lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass
 class Config:
-    """Typed representation of the ``config.toml`` contents."""
+    """Typed representation of the project configuration."""
 
     branch: str
     headless: bool
     delays: float
-    retries: int
-    base_period: str
+    max_retries: int
+    user_agent: str
+    output_dirs: list[Path]
 
 
 def _load_env(path: Path) -> None:
@@ -61,7 +69,53 @@ def load_config(
     with config_path.open("rb") as f:
         data = tomllib.load(f)
 
-    return Config(**data)
+    env = os.environ
+
+    branch = env.get("BRANCH", data.get("branch", "main"))
+    headless = _str_to_bool(env.get("HEADLESS", str(data.get("headless", True))))
+    delays = float(env.get("DELAYS", data.get("delays", 0)))
+    max_retries = int(env.get("MAX_RETRIES", data.get("max_retries", 0)))
+    user_agent = env.get("USER_AGENT", data.get("user_agent", ""))
+
+    if env.get("OUTPUT_DIRS"):
+        output_dirs = [Path(p.strip()) for p in env["OUTPUT_DIRS"].split(",") if p.strip()]
+    else:
+        output_dirs = [Path(p) for p in data.get("output_dirs", [])]
+
+    config = Config(
+        branch=branch,
+        headless=headless,
+        delays=delays,
+        max_retries=max_retries,
+        user_agent=user_agent,
+        output_dirs=output_dirs,
+    )
+
+    _ensure_playwright()
+    _ensure_output_dirs(config.output_dirs)
+
+    return config
+
+
+def _ensure_playwright() -> None:
+    """Verify that Playwright and the Chromium browser are installed."""
+
+    try:
+        from playwright.sync_api import sync_playwright
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            browser.close()
+    except Exception as exc:  # pragma: no cover - best effort check
+        raise RuntimeError(
+            "Playwright Chromium browser is not installed. Run 'playwright install chromium'."
+        ) from exc
+
+
+def _ensure_output_dirs(dirs: Iterable[Path]) -> None:
+    """Create output directories if they do not exist."""
+
+    for path in dirs:
+        path.mkdir(parents=True, exist_ok=True)
 
 
 __all__ = ["Config", "load_config"]


### PR DESCRIPTION
## Summary
- load configuration values from config.toml and .env
- check that Playwright's Chromium browser is installed and output folders exist
- document Playwright install and run command usage

## Testing
- `pip install playwright`
- `playwright install chromium` *(fails: Domain forbidden)*
- `PYTHONPATH=. pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68c1dbb039d883299e63946e2ac3b17e