### PR TITLE
Normalize unit parsing and add CBA cost calculations

### DIFF
--- a/src/index_engine.py
+++ b/src/index_engine.py
@@ -23,6 +23,15 @@ def calculate_cba(adjusted_catalog: List[Dict[str, Any]], sku_prices: Dict[str, 
 			missing.append(item)
 	return total, missing
 
+
+def cba_totals(costs: Dict[str, float]) -> Dict[str, float]:
+	"""Suma costos por ítem y calcula CBA para AE y familia tipo."""
+	total_ae = sum(costs.values())
+	return {
+	'cba_ae': total_ae,
+	'cba_familia': total_ae * 3.09,
+	}
+
 def calculate_index(series: pd.Series, base_period: str) -> pd.Series:
 	"""
 	Calcula el índice base=100 para la serie histórica de CBA.
@@ -38,6 +47,15 @@ def calculate_variations(index_series: pd.Series) -> pd.DataFrame:
 	df['var_mm'] = df['index'].pct_change() * 100
 	df['var_ia'] = df['index'].pct_change(12) * 100
 	return df
+
+
+def update_index_series(series: pd.Series, period: str, cba_ae: float, base_period: str) -> pd.DataFrame:
+	"""Actualiza la serie de CBA con un nuevo período y calcula índice y variaciones."""
+	updated = series.copy()
+	updated.loc[period] = cba_ae
+	updated = updated.sort_index()
+	index = calculate_index(updated, base_period)
+	return calculate_variations(index)
 
 def validate_series(df: pd.DataFrame) -> Dict[str, Any]:
 	"""

--- a/src/normalize/pricing.py
+++ b/src/normalize/pricing.py
@@ -17,3 +17,29 @@ def unit_price(price: float, pack_size: float, pack_unit: str, base_unit: str) -
     if base_qty == 0:
         raise ValueError("El tamaño del pack no puede ser cero")
     return price / base_qty
+
+
+def precio_unitario_base(price: float, presentation: str) -> tuple[float, str]:
+    """Calcula el precio por unidad base a partir de una presentación textual."""
+    from .units import parse_size
+
+    qty, unit = parse_size(presentation)
+    if qty <= 0:
+        raise ValueError("La cantidad debe ser positiva")
+    return price / qty, unit
+
+
+def costo_item_ae(
+    price: float,
+    presentation: str,
+    monthly_qty_value: float,
+    monthly_qty_unit: str,
+) -> float:
+    """Calcula el costo mensual del ítem por Adulto Equivalente."""
+    from .units import to_base_units
+
+    unit_price_val, base_unit = precio_unitario_base(price, presentation)
+    qty_base, qty_unit = to_base_units(monthly_qty_value, monthly_qty_unit)
+    if qty_unit != base_unit:
+        raise ValueError("Unidades incompatibles entre precio y cantidad mensual")
+    return unit_price_val * qty_base

--- a/src/normalize/units.py
+++ b/src/normalize/units.py
@@ -17,13 +17,14 @@ _unit_aliases = {
     'docena': 'docena', 'docenas': 'docena',
 }
 
+# Conversión a unidades base kg/L/unidad
 _unit_multipliers = {
-    'g': 1,
-    'kg': 1000,
-    'ml': 1,
-    'l': 1000,
+    'g': 0.001,     # gramos -> kg
+    'kg': 1,
+    'ml': 0.001,    # mililitros -> L
+    'l': 1,
     'unidad': 1,
-    'docena': 12,
+    'docena': 12,   # docena -> unidades
 }
 
 def _parse_fraction(s):
@@ -35,8 +36,8 @@ def _parse_fraction(s):
 
 def parse_size(text: str) -> Tuple[float, str]:
     """
-    Extrae cantidad y unidad base de una descripción textual.
-    Ej: 'x2 500g' -> (1000, 'g')
+    Extrae cantidad y unidad base (kg/L/unidad) de una descripción textual.
+    Ej: 'x2 500g' -> (1.0, 'kg')
     """
     text = text.lower().strip()
     # Multi-pack: xN ...
@@ -81,8 +82,8 @@ def parse_size(text: str) -> Tuple[float, str]:
 
 def to_base_units(value: float, unit: str) -> Tuple[float, str]:
     """
-    Convierte a unidad base (g, ml, unidad).
-    Ej: (1.5, 'kg') -> (1500, 'g')
+    Convierte a unidad base kg/L/unidad.
+    Ej: (500, 'g') -> (0.5, 'kg')
     """
     unit = unit.lower()
     if unit not in _unit_aliases:
@@ -93,8 +94,8 @@ def to_base_units(value: float, unit: str) -> Tuple[float, str]:
     mult = _unit_multipliers[canonical]
     if canonical == 'docena':
         return value * mult, 'unidad'
-    if canonical == 'kg':
-        return value * mult, 'g'
-    if canonical == 'l':
-        return value * mult, 'ml'
+    if canonical in ('g', 'kg'):
+        return value * mult, 'kg'
+    if canonical in ('ml', 'l'):
+        return value * mult, 'L'
     return value * mult, canonical

--- a/tests/unit/test_index_engine.py
+++ b/tests/unit/test_index_engine.py
@@ -25,6 +25,13 @@ def test_calculate_cba_ae_and_family():
     assert total_family == pytest.approx(total_ae * 3.09)
 
 
+def test_cba_totals():
+    costs = {"Pan": 100.0, "Leche": 200.0}
+    totals = index_engine.cba_totals(costs)
+    assert totals["cba_ae"] == 300.0
+    assert totals["cba_familia"] == pytest.approx(300.0 * 3.09)
+
+
 def test_calculate_index_and_variations():
     series = pd.Series({"2023-01": 500, "2023-02": 550})
     index = index_engine.calculate_index(series, "2023-01")
@@ -32,6 +39,13 @@ def test_calculate_index_and_variations():
     assert index.loc["2023-02"] == pytest.approx(110)
 
     df = index_engine.calculate_variations(index)
+    assert pytest.approx(df.loc["2023-02", "var_mm"], rel=1e-4) == 10.0
+
+
+def test_update_index_series():
+    series = pd.Series({"2023-01": 500})
+    df = index_engine.update_index_series(series, "2023-02", 550, "2023-01")
+    assert df.loc["2023-02", "index"] == pytest.approx(110)
     assert pytest.approx(df.loc["2023-02", "var_mm"], rel=1e-4) == 10.0
 
 

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -1,0 +1,16 @@
+"""Pruebas para cálculo de precios y costos por ítem."""
+from src.normalize.pricing import precio_unitario_base, costo_item_ae
+
+
+def test_precio_unitario_base():
+    price, unit = precio_unitario_base(200, "x2 500 g")
+    assert unit == "kg"
+    assert price == 200 / 1  # 200 por kg
+    price2, unit2 = precio_unitario_base(150, "1/2 kg")
+    assert unit2 == "kg"
+    assert price2 == 300  # 150 / 0.5
+
+
+def test_costo_item_ae():
+    cost = costo_item_ae(100, "1 kg", 2, "kg")
+    assert cost == 200

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -3,12 +3,16 @@ from src.normalize.units import parse_size, to_base_units
 
 
 def test_parse_size():
-    assert parse_size("1 kg") == (1000, "g")
-    assert parse_size("1 L") == (1000, "ml")
+    assert parse_size("1 kg") == (1, "kg")
+    assert parse_size("1 L") == (1, "L")
     assert parse_size("docena") == (12, "unidad")
+    assert parse_size("x2 500 g") == (1, "kg")
+    assert parse_size("1/2 kg") == (0.5, "kg")
 
 
 def test_to_base_units():
-    assert to_base_units(1, "kg") == (1000, "g")
-    assert to_base_units(2, "L") == (2000, "ml")
+    assert to_base_units(1, "kg") == (1, "kg")
+    assert to_base_units(500, "g") == (0.5, "kg")
+    assert to_base_units(2, "L") == (2, "L")
+    assert to_base_units(750, "ml") == (0.75, "L")
     assert to_base_units(1, "docena") == (12, "unidad")


### PR DESCRIPTION
## Summary
- normalize presentation parsing to kg/L/unidad and handle multipacks and fractions
- add helpers for precio_unitario_base, costo_item_ae, and CBA totals
- support index series updates and add tests for new pricing and index logic

## Testing
- `PYTHONPATH=. pytest tests/unit/test_units.py tests/unit/test_pricing.py tests/unit/test_index_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f48f76f483299b1b2f589a0246f9