### PR TITLE
feat: embed category chart and methodology notes

### DIFF
--- a/ipc-ushuaia/src/reporting/render.py
+++ b/ipc-ushuaia/src/reporting/render.py
@@ -35,7 +35,9 @@ def render_monthly_report(
     df_breakdown:
         Desglose de variaciones por ítem.
     img_paths:
-        Rutas a los gráficos a incrustar en el reporte.
+        Rutas o data URIs de los gráficos a incrustar en el reporte. Debe
+        incluir las claves ``index`` (serie del índice) y ``bars``
+        (variación por categoría).
     meta:
         Metadatos adicionales para el reporte. Si faltan las claves comunes,
         se completan con :func:`src.reporting.meta.build_meta`.

--- a/ipc-ushuaia/templates/monthly_report.html
+++ b/ipc-ushuaia/templates/monthly_report.html
@@ -22,6 +22,11 @@
         <!-- TODO: proveer descripciones más completas para lectores de pantalla -->
     </section>
 
+    <section id="category-chart">
+        <h2>Variación por categoría</h2>
+        <img src="{{ img_paths.bars }}" alt="Gráfico de variación por categoría" />
+    </section>
+
     <section id="breakdown">
         <h2>Top subas y bajas</h2>
         <table>
@@ -42,8 +47,12 @@
         </table>
     </section>
 
-    <footer>
+    <section id="methodology">
+        <h2>Notas metodológicas</h2>
         <p>{{ meta.methodology }}</p>
+    </section>
+
+    <footer>
         <p>Fuente: {{ meta.source }}</p>
         <p>Scraper v{{ meta.scraper_version }} | run_id: {{ meta.run_id }}</p>
     </footer>

--- a/ipc-ushuaia/tests/test_rendering.py
+++ b/ipc-ushuaia/tests/test_rendering.py
@@ -2,7 +2,12 @@ import pandas as pd
 from pathlib import Path
 
 from src.reporting.render import render_monthly_report
-from src.reporting.meta import build_meta, SCRAPER_VERSION, SOURCE
+from src.reporting.meta import (
+    build_meta,
+    SCRAPER_VERSION,
+    SOURCE,
+    SUMMARY_METHODOLOGY,
+)
 
 
 def test_render_monthly_report(tmp_path):
@@ -17,14 +22,17 @@ def test_render_monthly_report(tmp_path):
     series["yoy"] = series["idx"].pct_change(12) * 100
 
     breakdown = pd.DataFrame({"item": ["A", "B"], "delta": [1.5, -0.5]})
-    img_paths = {"index": "index.png"}
+    img_paths = {"index": "index.png", "bars": "bars.png"}
 
     meta = build_meta(run_id="test-run")
     output = render_monthly_report(period, series, breakdown, img_paths, meta)
     assert output.exists()
     html = output.read_text(encoding="utf-8")
     assert "Indicadores Clave" in html
+    assert "Variación por categoría" in html
+    assert "Notas metodológicas" in html
     assert "Top subas y bajas" in html
     assert SOURCE in html
     assert f"Scraper v{SCRAPER_VERSION}" in html
     assert "run_id: test-run" in html
+    assert SUMMARY_METHODOLOGY in html


### PR DESCRIPTION
## Summary
- embed category bar chart and methodology section in monthly report template
- document required image keys for report rendering
- extend rendering test to cover new sections and metadata

## Testing
- `pytest ipc-ushuaia/tests/test_exporter.py ipc-ushuaia/tests/test_rendering.py ipc-ushuaia/tests/test_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2f784e08c8329a3d228388d37d03b