### PR TITLE
Add evidence capture and run threshold checks

### DIFF
--- a/ipc-ushuaia/src/scraper/__init__.py
+++ b/ipc-ushuaia/src/scraper/__init__.py
@@ -1,0 +1,8 @@
+"""Scraper utilities and helpers."""
+
+__all__ = [
+    "browser",
+    "extract",
+    "search",
+    "utils",
+]

--- a/ipc-ushuaia/src/scraper/utils.py
+++ b/ipc-ushuaia/src/scraper/utils.py
@@ -1,12 +1,34 @@
-"""Helpers for scraper: saving HTML evidence on failures."""
+"""Helpers for scraper: capture HTML and screenshots as evidence."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from uuid import uuid4
+from typing import Dict
+
+from src.infra.logging import get_logger
 
 
-def save_html(content: str, prefix: str, *, base_dir: str = "data/evidence") -> Path:
+logger = get_logger(__name__)
+
+
+def _run_dir(base_dir: str | Path, run_id: str | None) -> Path:
+    """Return the directory where evidence for ``run_id`` will be stored."""
+
+    path = Path(base_dir)
+    if run_id:
+        path = path / run_id
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def save_html(
+    content: str,
+    prefix: str,
+    *,
+    base_dir: str = "data/evidence",
+    run_id: str | None = None,
+) -> Path:
     """Persist raw HTML for later auditing.
 
     Parameters
@@ -17,14 +39,59 @@ def save_html(content: str, prefix: str, *, base_dir: str = "data/evidence") -> 
         Prefix for the generated file name.
     base_dir:
         Directory where files will be stored.
+    run_id:
+        Identifier for the current run. When provided, evidence is saved under
+        ``<base_dir>/<run_id>/``.
 
     Returns
     -------
     pathlib.Path
         Path to the written file.
     """
-    path = Path(base_dir)
-    path.mkdir(parents=True, exist_ok=True)
+
+    path = _run_dir(base_dir, run_id)
     file = path / f"{prefix}_{uuid4().hex}.html"
     file.write_text(content, encoding="utf-8")
+    logger.info("Saved HTML evidence", extra={"path": str(file)})
     return file
+
+
+def save_screenshot(
+    page,
+    prefix: str,
+    *,
+    base_dir: str = "data/evidence",
+    run_id: str | None = None,
+) -> Path:
+    """Capture a screenshot from ``page`` and persist it.
+
+    ``page`` is expected to provide a ``screenshot`` method compatible with
+    ``playwright.sync_api.Page``.
+    """
+
+    path = _run_dir(base_dir, run_id)
+    file = path / f"{prefix}_{uuid4().hex}.png"
+    page.screenshot(path=str(file))
+    logger.info("Saved screenshot evidence", extra={"path": str(file)})
+    return file
+
+
+def capture_evidence(
+    page,
+    prefix: str,
+    run_id: str,
+    *,
+    base_dir: str = "data/evidence",
+) -> Dict[str, Path]:
+    """Save both HTML and a screenshot for the current ``page``.
+
+    Returns a mapping with paths to the written files under keys ``html`` and
+    ``screenshot``.
+    """
+
+    html_path = save_html(page.content(), prefix, base_dir=base_dir, run_id=run_id)
+    shot_path = save_screenshot(page, prefix, base_dir=base_dir, run_id=run_id)
+    return {"html": html_path, "screenshot": shot_path}
+
+
+__all__ = ["save_html", "save_screenshot", "capture_evidence"]

--- a/ipc-ushuaia/tests/test_utils.py
+++ b/ipc-ushuaia/tests/test_utils.py
@@ -1,0 +1,29 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from scraper.utils import capture_evidence, save_html
+
+
+class DummyPage:
+    def content(self):
+        return "<html></html>"
+
+    def screenshot(self, path: str):
+        Path(path).write_bytes(b"fake")
+
+
+def test_capture_evidence(tmp_path):
+    page = DummyPage()
+    result = capture_evidence(page, "item", "run1", base_dir=tmp_path)
+    assert result["html"].exists()
+    assert result["screenshot"].exists()
+    assert result["html"].parent == tmp_path / "run1"
+    assert result["screenshot"].parent == tmp_path / "run1"
+
+
+def test_save_html_run_id(tmp_path):
+    path = save_html("<p>ok</p>", "test", base_dir=tmp_path, run_id="run2")
+    assert path.exists()
+    assert path.parent == tmp_path / "run2"

--- a/tests/unit/test_alerts_thresholds.py
+++ b/tests/unit/test_alerts_thresholds.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+import src.alerts as alerts
+
+
+def test_enforce_thresholds_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(alerts, "evidence_dir", tmp_path)
+    items = {
+        "a": {"price": 10},
+        "b": {"price": None},
+    }
+    flag = tmp_path / "flag.txt"
+    with pytest.raises(SystemExit):
+        alerts.enforce_thresholds(items, {}, min_valid_items=2, variation_tolerance=5, flag_file=flag)
+    assert flag.exists()
+
+
+def test_enforce_thresholds_variation(tmp_path, monkeypatch):
+    monkeypatch.setattr(alerts, "evidence_dir", tmp_path)
+    items = {
+        "a": {"price": 10},
+        "b": {"price": 20},
+    }
+    flag = tmp_path / "flag.txt"
+    with pytest.raises(SystemExit):
+        alerts.enforce_thresholds(items, {"foo": 12}, min_valid_items=2, variation_tolerance=10, flag_file=flag)
+    assert flag.exists()
+
+
+def test_enforce_thresholds_ok(tmp_path, monkeypatch):
+    monkeypatch.setattr(alerts, "evidence_dir", tmp_path)
+    items = {
+        "a": {"price": 10},
+        "b": {"price": 20},
+    }
+    variations = {"foo": 1.0}
+    flag = tmp_path / "flag.txt"
+    alerts.enforce_thresholds(items, variations, min_valid_items=2, variation_tolerance=5, flag_file=flag)
+    assert not flag.exists()


### PR DESCRIPTION
## Summary
- save HTML and screenshots for sample items in run-specific directories
- enforce minimum valid items and variation thresholds with flag alerts
- cover evidence helpers and threshold logic with tests

## Testing
- `PYTHONPATH=. pytest tests/unit -q`
- `PYTHONPATH=ipc-ushuaia/src:. pytest ipc-ushuaia/tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2fb2e6a388329bae413d663c38d7e