### PR TITLE
Add evidence capture and run threshold checks

### DIFF
--- a/src/alerts.py
+++ b/src/alerts.py
@@ -165,6 +165,21 @@ def enforce_thresholds(
 
     total = len(items)
     missing = [name for name, info in items.items() if info.get("price") is None]
+    valid = total - len(missing)
+    insufficient_triggered = False
+    if valid < min_valid_items:
+        body = (
+            f"Se obtuvieron {valid} ítems con precio válido "
+            f"(mínimo requerido {min_valid_items})."
+        )
+        _dispatch(
+            "Alerta: faltantes de ítems",
+            body,
+            email=email,
+            flag_file=flag_file,
+        )
+        insufficient_triggered = True
+
     allowed_missing = max(total - min_valid_items, 0)
 
     missing_triggered = alert_missing_items(
@@ -181,7 +196,7 @@ def enforce_thresholds(
         flag_file=flag_file,
     )
 
-    if missing_triggered or variation_triggered:
+    if insufficient_triggered or missing_triggered or variation_triggered:
         raise SystemExit(1)
 
 

--- a/tests/unit/test_alerts_thresholds.py
+++ b/tests/unit/test_alerts_thresholds.py
@@ -17,6 +17,18 @@ def test_enforce_thresholds_missing(tmp_path, monkeypatch):
     assert flag.exists()
 
 
+def test_enforce_thresholds_insufficient(tmp_path, monkeypatch):
+    monkeypatch.setattr(alerts, "evidence_dir", tmp_path)
+    items = {
+        "a": {"price": 10},
+        "b": {"price": 20},
+    }
+    flag = tmp_path / "flag.txt"
+    with pytest.raises(SystemExit):
+        alerts.enforce_thresholds(items, {}, min_valid_items=3, variation_tolerance=5, flag_file=flag)
+    assert flag.exists()
+
+
 def test_enforce_thresholds_variation(tmp_path, monkeypatch):
     monkeypatch.setattr(alerts, "evidence_dir", tmp_path)
     items = {


### PR DESCRIPTION
## Summary
- save HTML and screenshots for sample items in run-specific directories
- enforce minimum valid items and variation thresholds with flag alerts
- cover evidence helpers and threshold logic with tests
- validate minimum item count even when all returned items have prices

## Testing
- `PYTHONPATH=. pytest tests/unit -q`
- `PYTHONPATH=ipc-ushuaia/src:. pytest ipc-ushuaia/tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2ff8e8cfc8329b0d365f5bd1b5c48