### PR TITLE
docs: add evidence references and export docs

### DIFF
--- a/ipc-ushuaia/src/exporter.py
+++ b/ipc-ushuaia/src/exporter.py
@@ -13,6 +13,14 @@ from typing import Optional
 
 import pandas as pd
 
+__all__ = [
+    "export_to_csv",
+    "export_to_json",
+    "export_to_html",
+    "export_series",
+    "export_breakdown",
+]
+
 
 # Directorio base para las exportaciones
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -51,6 +59,11 @@ def export_to_html(df: pd.DataFrame, path: str) -> None:
 
 def export_series(df: pd.DataFrame, output: Optional[str] = None) -> Path:
     """Exporta la serie histórica de la CBA.
+
+    TODO: consolidar campos derivados y anotar en
+    ``docs/evidence/export_series.md``.
+    Evidencia: ``docs/evidence/export_series.md``
+    Export: ``exports/series_cba.csv``
 
     Parameters
     ----------

--- a/ipc-ushuaia/src/metrics/cba.py
+++ b/ipc-ushuaia/src/metrics/cba.py
@@ -1,16 +1,27 @@
-"""
-Cálculo del costo de la Canasta Básica Alimentaria (CBA) para un Adulto Equivalente (AE).
-"""
+"""Cálculo del costo de la Canasta Básica Alimentaria (CBA)."""
+
 import pandas as pd
-from typing import List, Dict, Any
+
+__all__ = ["compute_cba_ae", "compute_cba"]
+
 
 def compute_cba_ae(prices: pd.DataFrame, basket: pd.DataFrame) -> float:
+    """Calcula el costo total de la CBA para un Adulto Equivalente.
+
+    TODO: validar redondeos y actualizar ``docs/evidence/compute_cba_ae.md``.
+    Evidencia: ``docs/evidence/compute_cba_ae.md``
+    Export: ``exports/cba_ae.csv``
     """
-    Calcula el costo total de la CBA para un Adulto Equivalente.
-    prices: DataFrame con columnas ['sku', 'unit_price']
-    basket: DataFrame con columnas ['sku', 'quantity']
-    Retorna el costo total (float).
+    merged = pd.merge(basket, prices, on="sku", how="inner")
+    merged["total"] = merged["quantity"] * merged["unit_price"]
+    return merged["total"].sum()
+
+
+def compute_cba(prices: pd.DataFrame, basket: pd.DataFrame) -> float:
+    """Conveniencia que delega en :func:`compute_cba_ae`.
+
+    TODO: consolidar metodología y dejar evidencia en ``docs/evidence/compute_cba.md``.
+    Evidencia: ``docs/evidence/compute_cba.md``
+    Export: ``exports/cba_series.csv``
     """
-    merged = pd.merge(basket, prices, on='sku', how='inner')
-    merged['total'] = merged['quantity'] * merged['unit_price']
-    return merged['total'].sum()
+    return compute_cba_ae(prices, basket)

--- a/ipc-ushuaia/src/reporting/render.py
+++ b/ipc-ushuaia/src/reporting/render.py
@@ -10,6 +10,8 @@ from jinja2 import Environment, FileSystemLoader
 
 from .meta import build_meta
 
+__all__ = ["render_monthly_report"]
+
 # Directorio base del proyecto
 BASE_DIR = Path(__file__).resolve().parents[2]
 TEMPLATE_DIR = BASE_DIR / "templates"
@@ -24,6 +26,11 @@ def render_monthly_report(
     meta: Dict[str, Any],
 ) -> Path:
     """Genera un reporte mensual en HTML.
+
+    TODO: evaluar plantillas y documentar en
+    ``docs/evidence/render_monthly_report.md``.
+    Evidencia: ``docs/evidence/render_monthly_report.md``
+    Export: ``reports/monthly_<period>.html``
 
     Parameters
     ----------

--- a/ipc-ushuaia/src/scraper/branch.py
+++ b/ipc-ushuaia/src/scraper/branch.py
@@ -1,24 +1,31 @@
-"""
-Selección y persistencia de sucursal en La Anónima Online.
-"""
+"""Selección y persistencia de sucursal en La Anónima Online."""
 
-def select_branch(page, city: str = "Ushuaia") -> None:
-    """
-    Selecciona la sucursal deseada en la web y persiste la selección.
-    Args:
-        page: Instancia de página Playwright.
-        city (str): Nombre de la ciudad/sucursal.
+from playwright.sync_api import Page
+
+__all__ = ["select_branch", "get_current_branch"]
+
+
+def select_branch(page: Page, city: str = "Ushuaia") -> None:
+    """Selecciona la sucursal deseada en la web y persiste la selección.
+
+    TODO: Implementar interacción con el modal de sucursales.
+    Evidencia: ``docs/evidence/select_branch.md``
+    Export: ``exports/branch_selection.html``
+
+    Parameters
+    ----------
+    page:
+        Instancia de página Playwright.
+    city:
+        Nombre de la ciudad/sucursal.
     """
     # TODO: Interactuar con el selector de sucursal
     pass
 
-def get_current_branch(page) -> str:
-    """
-    Devuelve la sucursal actualmente seleccionada.
-    Args:
-        page: Instancia de página Playwright.
-    Returns:
-        str: Nombre de la sucursal seleccionada.
-    """
+
+def get_current_branch(page: Page) -> str:
+    """Devuelve la sucursal actualmente seleccionada."""
+
     # TODO: Extraer sucursal actual
-    pass
+    # Evidencia: ``docs/evidence/get_current_branch.md``
+    return ""  # TODO: Retornar la sucursal real

--- a/ipc-ushuaia/src/scraper/extract.py
+++ b/ipc-ushuaia/src/scraper/extract.py
@@ -9,9 +9,15 @@ from bs4 import BeautifulSoup
 
 from .utils import save_html
 
+__all__ = ["extract_product_cards", "normalize_product"]
+
 
 def extract_product_cards(html: str) -> List[Dict]:
     """Parsea tarjetas de productos desde el HTML de resultados.
+
+    TODO: documentar cambios de selectores en ``docs/evidence/extract_cards.md``.
+    Evidencia: ``docs/evidence/extract_cards.md``
+    Export: ``exports/raw_cards.json``
 
     Se busca un precio promocional (``ahora``) cuando esté disponible y se
     marca el producto como *out of stock* si corresponde.
@@ -41,7 +47,12 @@ _PRICE_RE = re.compile(r"[0-9]+(?:[.,][0-9]+)?")
 
 
 def normalize_product(raw: dict) -> dict:
-    """Normaliza un producto crudo a un contrato estándar."""
+    """Normaliza un producto crudo a un contrato estándar.
+
+    TODO: estandarizar unidades y registrar notas en
+    ``docs/evidence/normalize_product.md``.
+    Export: ``exports/normalized_products.json``
+    """
 
     price_match = _PRICE_RE.search(raw["price"])
     price = float(price_match.group(0).replace(".", "").replace(",", ".")) if price_match else None

--- a/ipc-ushuaia/src/scraper/search.py
+++ b/ipc-ushuaia/src/scraper/search.py
@@ -10,10 +10,16 @@ from src.infra.retry import exponential_backoff
 
 from .utils import is_allowed, random_delay, save_html
 
+__all__ = ["search", "list_category", "paginate"]
+
 
 @exponential_backoff(max_attempts=3)
 def search(page: Page, query: str) -> str:
     """Realiza una búsqueda y retorna el HTML resultante.
+
+    TODO: registrar cambios de DOM al expedir ``docs/evidence/search.md``.
+    Evidencia: ``docs/evidence/search_{query}.html``
+    Export: ``exports/search_{query}.html``
 
     Se emplean selectores basados en ``data-testid`` y espera explícita para
     asegurar que los resultados estén cargados antes de extraer el HTML.


### PR DESCRIPTION
## Summary
- document scraper functions with TODO notes and evidence/export paths
- expose public API with __all__ declarations
- add compute_cba wrapper with documentation

## Testing
- `pip install requests`
- `pip install responses`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src.alerts')*
- `pytest ipc-ushuaia/src/metrics/test_cba.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3129bd3d883299fa5b37c78398254