### PR TITLE
Implement home-based search flow

### DIFF
--- a/ipc-ushuaia/src/scraper/search.py
+++ b/ipc-ushuaia/src/scraper/search.py
@@ -40,6 +40,7 @@ def search(page: Page, query: str, home_url: str = "https://supermercado.laanoni
             page.wait_for_selector("div.producto")
         except TimeoutError:
             save_html(page.content(), f"search_{query}")
+            raise
         return page.content()
     except Exception:
         save_html(page.content(), "search_error")


### PR DESCRIPTION
## Summary
- navigate to home URL before searching and capture HTML when product results are missing
- add responses dependency and pytest config to resolve import errors
- raise TimeoutError when search results fail to load

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3710540688329b4d7726b286cf80e