### PR TITLE
feat: implement branch selection

### DIFF
--- a/ipc-ushuaia/src/scraper/branch.py
+++ b/ipc-ushuaia/src/scraper/branch.py
@@ -1,6 +1,12 @@
 """Selección y persistencia de sucursal en La Anónima Online."""
 
+from __future__ import annotations
+
+import re
+
 from playwright.sync_api import Page
+
+from .utils import capture_evidence
 
 __all__ = ["select_branch", "get_current_branch"]
 
@@ -8,7 +14,6 @@ __all__ = ["select_branch", "get_current_branch"]
 def select_branch(page: Page, city: str = "Ushuaia") -> None:
     """Selecciona la sucursal deseada en la web y persiste la selección.
 
-    TODO: Implementar interacción con el modal de sucursales.
     Evidencia: ``docs/evidence/select_branch.md``
     Export: ``exports/branch_selection.html``
 
@@ -19,13 +24,60 @@ def select_branch(page: Page, city: str = "Ushuaia") -> None:
     city:
         Nombre de la ciudad/sucursal.
     """
-    # TODO: Interactuar con el selector de sucursal
-    pass
+
+    selector = "div.sucursal_actual"
+    try:
+        current = page.inner_text(selector).strip()
+    except Exception:
+        capture_evidence(page, "branch_detect_error", run_id="branch")
+        raise
+
+    if city.lower() in current.lower():
+        return
+
+    try:
+        page.click(selector)
+        page.wait_for_selector("text=Tierra del Fuego")
+        page.get_by_text("Tierra del Fuego").click()
+        page.wait_for_selector(f"text={city}")
+        page.get_by_text(city).click()
+
+        # Intentar distintos textos de botón de confirmación
+        try:
+            page.get_by_role("button", name=re.compile("Ingresar|Aceptar|Confirmar", re.I)).click()
+        except Exception:
+            pass
+
+        page.wait_for_function(
+            """
+            (city) => {
+                const el = document.querySelector('div.sucursal_actual');
+                if (!el) return false;
+                const text = (el.textContent || '').toLowerCase();
+                const title = (el.getAttribute('title') || '').toLowerCase();
+                return text.includes(city.toLowerCase()) || title.includes(city.toLowerCase());
+            }
+            """,
+            arg=city,
+            timeout=5000,
+        )
+
+        updated = page.inner_text(selector).strip()
+        title_attr = page.get_attribute(selector, "title") or ""
+        if city.lower() not in updated.lower() and city.lower() not in title_attr.lower():
+            raise RuntimeError("Branch selection validation failed")
+
+    except Exception:
+        capture_evidence(page, "branch_selection_error", run_id="branch")
+        raise
 
 
 def get_current_branch(page: Page) -> str:
     """Devuelve la sucursal actualmente seleccionada."""
 
-    # TODO: Extraer sucursal actual
-    # Evidencia: ``docs/evidence/get_current_branch.md``
-    return ""  # TODO: Retornar la sucursal real
+    selector = "div.sucursal_actual"
+    try:
+        return page.inner_text(selector).strip()
+    except Exception:
+        capture_evidence(page, "get_current_branch_error", run_id="branch")
+        raise


### PR DESCRIPTION
## Summary
- add branch selection logic using Playwright, including modal navigation and validation
- expose helper to fetch current branch with evidence capture

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c371a83c98832988a1f57128c43c40