### PR TITLE
feat: parse legacy imetrics cards

### DIFF
--- a/docs/evidence/extract_cards.md
+++ b/docs/evidence/extract_cards.md
@@ -1,6 +1,17 @@
 # extract_cards.md — selectores DOM
 
+## Variante con `data-testid`
+
 - Precio promocional: `div.precio-promo > div.precio.semibold` + `span.decimales`.
 - Precio regular: `div.precio` + `div.precio_complemento span.decimales`.
 - Impuestos: `div.impuestos-nacionales`.
 - Bandera de promoción: `promo_flag` se activa si se usa `div.precio-promo`.
+
+## Variante "imetrics"
+
+- Productos listados en `div.producto.item`.
+- Nombre y URL: `a[id^='btn_nombre_imetrics_']`.
+- Precio base: `input[id^='precio_item_imetrics_']`.
+- Precio oferta: `input[id^='precio_oferta_item_imetrics_']` (si existe).
+- Marca y SKU: `input[id^='brand_item_imetrics_']` y `input[id^='sku_item_imetrics_']`.
+- Stock: `div.btnagregarcarritosinstock_*` con `style='display:none'` indica disponible.

--- a/tests/unit/test_extract_imetrics.py
+++ b/tests/unit/test_extract_imetrics.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+# Añade ruta al scraper dentro de ipc-ushuaia
+sys.path.append(str(Path(__file__).resolve().parents[2] / "ipc-ushuaia" / "src"))
+
+from scraper.extract import extract_product_cards_imetrics
+
+
+def test_extract_imetrics_with_offer_and_stock():
+    html = """
+    <div class="producto item">
+      <a id="btn_nombre_imetrics_1" href="http://example.com/a">Producto A</a>
+      <input type="hidden" id="precio_item_imetrics_1" value="1200,00" />
+      <input type="hidden" id="precio_oferta_item_imetrics_1" value="1000,00" />
+      <input type="hidden" id="brand_item_imetrics_1" value="MarcaA" />
+      <input type="hidden" id="sku_item_imetrics_1" value="SKU1" />
+      <div class="btnagregarcarritosinstock_1" style="display:none;"></div>
+    </div>
+    """
+    cards = extract_product_cards_imetrics(html)
+    assert cards[0] == {
+        "sku": "SKU1",
+        "nombre": "Producto A",
+        "marca": "MarcaA",
+        "url": "http://example.com/a",
+        "precio_final": 1000.0,
+        "promo_flag": True,
+        "in_stock": True,
+    }
+
+
+def test_extract_imetrics_without_offer_oos():
+    html = """
+    <div class="producto item">
+      <a id="btn_nombre_imetrics_2" href="http://example.com/b">Producto B</a>
+      <input type="hidden" id="precio_item_imetrics_2" value="1500,50" />
+      <input type="hidden" id="brand_item_imetrics_2" value="MarcaB" />
+      <input type="hidden" id="sku_item_imetrics_2" value="SKU2" />
+      <div class="btnagregarcarritosinstock_2"></div>
+    </div>
+    """
+    cards = extract_product_cards_imetrics(html)
+    assert cards[0] == {
+        "sku": "SKU2",
+        "nombre": "Producto B",
+        "marca": "MarcaB",
+        "url": "http://example.com/b",
+        "precio_final": 1500.50,
+        "promo_flag": False,
+        "in_stock": False,
+    }
+


### PR DESCRIPTION
## Summary
- add `extract_product_cards_imetrics` to parse legacy imetrics DOM and compute final price and stock
- document imetrics selectors in `extract_cards.md`
- test imetrics extraction for promo price and stock handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c373e38f34832997c192a7b35af15f